### PR TITLE
chore: fix ci test run

### DIFF
--- a/.github/workflows/reusable-verify.yaml
+++ b/.github/workflows/reusable-verify.yaml
@@ -50,15 +50,14 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
 
-        # TODO: Let's create an anvil service container for this instead.
-      - name: Launch anvil
-        run: anvil --fork-url ${{ secrets.ANVIL_FORK_URL }} --fork-block-number ${{ secrets.ANVIL_FORK_BLOCK_NUMBER }} &
-
       - name: Run build
         run: pnpm run build
 
       - name: Run tests
         run: pnpm run test
+        env:
+          VITEST_ANVIL_FORK_URL: ${{ secrets.VITEST_ANVIL_FORK_URL }}
+          VITEST_ANVIL_FORK_BLOCK_NUMBER: ${{ secrets.VITEST_ANVIL_FORK_BLOCK_NUMBER }}
 
   size:
     name: Size

--- a/packages/sdk/src/actions/redeemSharesInKind.test.ts
+++ b/packages/sdk/src/actions/redeemSharesInKind.test.ts
@@ -3,6 +3,9 @@ import { toSeconds, toWei } from "../utils/conversion.js";
 import { publicClient, sendTestTransaction, testActions } from "../../tests/globals.js";
 import { ALICE, WETH } from "../../tests/constants.js";
 import { simulateRedeemSharesInKind } from "./redeemSharesInKind.js";
+import { setupAnvil } from "../../tests/anvil.js";
+
+setupAnvil();
 
 test("redeem shares in kind should work correctly", async () => {
   const { comptrollerProxy, vaultProxy } = await testActions.createTestVault({

--- a/packages/sdk/tests/anvil.ts
+++ b/packages/sdk/tests/anvil.ts
@@ -45,14 +45,14 @@ export function setupAnvil({
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
     }
-  }, 1000);
+  }, 10000);
 
   beforeEach(async () => {
     await testClient.reset({
       blockNumber: BigInt(forkBlockNumber),
       ...(forkUrl ? { jsonRpcUrl: forkUrl } : {}),
     });
-  }, 1000);
+  }, 10000);
 
   afterAll(async () => {
     signal.abort();
@@ -60,5 +60,5 @@ export function setupAnvil({
     try {
       await subprocess;
     } catch (error) {}
-  }, 1000);
+  }, 10000);
 }


### PR DESCRIPTION


<!-- start pr-codex -->

## PR-Codex overview
This PR increases the timeout values for some async functions and adds Anvil setup to a test file. 

### Detailed summary:
- Increased timeout values for async functions in `packages/sdk/tests/anvil.ts` from 1000 to 10000.
- Imported and called `setupAnvil()` function in `packages/sdk/src/actions/redeemSharesInKind.test.ts`.
- Removed the `anvil` command from the reusable-verify.yaml file and added two new environment variables: `VITEST_ANVIL_FORK_URL` and `VITEST_ANVIL_FORK_BLOCK_NUMBER`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->